### PR TITLE
svd: Add .svd generation scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 _readthedocs/
 *.html
+*.svd

--- a/svd/Makefile
+++ b/svd/Makefile
@@ -1,0 +1,12 @@
+EMACS ?= emacs
+OXSVD ?= $(realpath $(shell pwd)/../scripts/svd/ox-svd.el)
+SRC = svd.org
+DEPS = $(shell $(EMACS) --script print-dependencies.el $(SRC))
+
+all: scobc-a1.svd
+
+scobc-a1.svd: $(SRC) $(OXSVD) $(DEPS)
+	$(EMACS) $< --batch --load $(OXSVD) -f org-svd-export-to-svd --kill
+
+clean:
+	$(RM) *.svd *~

--- a/svd/print-dependencies.el
+++ b/svd/print-dependencies.el
@@ -1,0 +1,10 @@
+(unless (= 1 (length command-line-args-left))
+  (user-error "Usage: emacs --script %s FILE" (file-name-nondirectory load-file-name)))
+
+(require 'org)
+(find-file-read-only (car command-line-args-left))
+(org-element-map (org-element-parse-buffer) 'keyword
+  (lambda (kw)
+    (let ((key (org-element-property :key kw)))
+      (when (string= key "INCLUDE")
+        (princ (format "%s\n" (string-trim (org-element-property :value kw) "\"" "\"")))))))

--- a/svd/svd.org
+++ b/svd/svd.org
@@ -1,0 +1,12 @@
+#+TITLE: Space Cubics OBC module A1
+#+EXPORT_FILE_NAME: scobc-a1.svd
+
+# #+INCLUDE: "../interrupt.org"
+#+INCLUDE: "../system_register.org"
+# #+INCLUDE: "../system_monitor.org"
+#+INCLUDE: "../general_purpose_timer.org"
+#+INCLUDE: "../hrmem.org"
+#+INCLUDE: "../qspi_controller.org"
+#+INCLUDE: "../can_controller.org"
+#+INCLUDE: "../ahb_uart_lite.org"
+#+INCLUDE: "../i2c_master_controller.org"


### PR DESCRIPTION
Add svd generation script and Makefile.  scripts/svd/ is subtree merge from yashi/org-svd.

To generate a svd, just run `make` in $TOP/svd/ directory.