### PR TITLE
fpga: Clarify Cortex-M3 interrupt description

### DIFF
--- a/ja/modules/fpga/pages/interrupt.adoc
+++ b/ja/modules/fpga/pages/interrupt.adoc
@@ -1,13 +1,18 @@
 = Interrupt
 
-SC-OBC-A1 FPGAは、Cortex-M3に組み込まれる割り込みコントローラの外部割り込みを使用し、IPコアの割り込みをCPUに伝えます。
-Cortex-M3の 割り込みコントローラの仕様については、ARM Cortex-M3 Technical Reference Manualを参照してください。
+SC-OBC-A1 FPGA では、IP コアからの割り込みを CPU に通知するために、
+Cortex-M3 内蔵の割り込みコントローラ (NVIC) の外部割り込み入力を使用します。
 
-IRQ Bit [31:16]は、Mission Bus Systemに割り当てられた割り込みビットです。
-ユーザーが設計した回路に応じて割り当てが決定します。
+Cortex-M3 の割り込みコントローラの仕様については、
+ARM Cortex-M3 Technical Reference Manual を参照してください。
 
-以下に、SC-OBC-A1 FPGAの IPコアが出力する割り込みの割り当てを示します。
-IRQ Bit [31:16]は、標準イメージにて実装されている割り込みビットです。
+IRQ Bit [31:16]は、Mission Bus System に割り当てられた割り込みビットです。
+割り込みビットの割り当ては、ユーザーが設計した回路に応じて決まります。
+
+以下に、SC-OBC-A1 FPGA の IP コアが出力する割り込みの割り当てを示します。
+標準イメージでは、IRQ Bit [16] から [25] が IP コアに割り当てられ、
+IRQ Bit [31:26] は予約領域です。
+
 
 .SC-OBC-A1 FPGA割り込みリスト
 [cols=",,,",options="header",]


### PR DESCRIPTION
Clarify the interrupt description for the SC-OBC-A1 FPGA.

The updated text explains that interrupts from IP cores are notified to the CPU through the external interrupt inputs of the Cortex-M3 NVIC.

Also clarify the IRQ bit assignments in the standard image. IRQ bits [16] through [25] are assigned to IP cores, while IRQ bits [31:26] are reserved.